### PR TITLE
Error when hidding keyboard and using Navigation extension

### DIFF
--- a/js/jquery.keyboard.extension-navigation.js
+++ b/js/jquery.keyboard.extension-navigation.js
@@ -79,7 +79,7 @@ $.fn.addNavigation = function(options){
 		};
 
 		base.checkKeys = function(key, disable){
-                        if (key == undefined) {
+                        if (typeof(key) === "undefined") {
                             return;
                         }
                         var k = base.navigation_keys;


### PR DESCRIPTION
When keyboard is being hidden, a call to navigation extension checkKeys() method is made but with an undefined key. That's the way to detect base.$keyboard doesn't exist and return instead of throwing an exception
