### PR TITLE
Resolved issue with FlashOfUnstyledContent (FOUC) when using jQuery Mobile

### DIFF
--- a/js/jquery.keyboard.extension-mobile.js
+++ b/js/jquery.keyboard.extension-mobile.js
@@ -63,10 +63,21 @@ $.fn.addMobile = function(options){
 				base.mobile_setup();
 			}
 
-			// Setup mobile theme on keyboard once it is visible
-			base.$el.bind('visible.keyboard', function() {
+			// Setup mobile theme on keyboard once it is visible.
+			// Note: There is a 10ms delay after the keyboard is displayed before it actually fires 'visible.keyboard'. 
+			// Since we are restyling here, the user will experience FlashOfUnstyledContent (FOUC).
+			// This is avoided by first setting the visibility to hidden, then after the mobile styles are applied we 
+			// set it visible.
+			//
+			base.$el.on('beforeVisible.keyboard', function () {
+				if (base.mobile_initialized !== true) {
+					base.$keyboard.css("visibility", "hidden");
+				}
+			})
+			.on('visible.keyboard', function () {
 				if (base.mobile_initialized !== true) {
 					base.mobile_setup();
+					base.$keyboard.css("visibility", "visible");
 				}
 			});
 


### PR DESCRIPTION
There is a 10ms delay after the keyboard is displayed before it actually fires 'visible.keyboard'. 
Since the jQuery Mobile plugin restyles the controls in response to the 'visible.keyboard' event, the user will experience FlashOfUnstyledContent (FOUC).  I guess technically it's not unstyled -- just the wrong style.

This fix, or workaround rather, avoids this FOUC by first setting the visibility to hidden on 'beforeVisible.keyboard' so that the user doesn't see anything during the delay, then after the mobile styles are applied we set it visible.

This may not be ideal -- but I couldn't think of a better way to approach this without purposely eliminating the setTimeout delay in the core code or by adding another event before the setTimeout.

You don't see the issue in the demo page for jQM, because its not showing keyboards in response to <input> touches/clicks.  If you'd prefer to see some test cases, I can put together some fiddles later.

Also, I didn't get a chance to do the minified version.  I'm expecting to do another PR, hopefully by Monday.
