### PR TITLE
Fixed issue preventing numeric key clicks/touches from registering due to reference error

### DIFF
--- a/jquery-mobile-1.4.html
+++ b/jquery-mobile-1.4.html
@@ -61,6 +61,8 @@ $.widget("bw.virtualNumericKeyboard", {
                 "default": ["7 8 9 {b}", "4 5 6 {clear}", "1 2 3 {sign}", "0 {dec} {accept}"]
             },
 
+            usePreview: false,
+
             beforeVisible: $.proxy(self._onKeyboardBeforeVisible, self),
 
             create: $.proxy(self._onCreateKeyboard, self),

--- a/js/jquery.keyboard.js
+++ b/js/jquery.keyboard.js
@@ -502,7 +502,7 @@ $.keyboard = function(el, options){
 				// 'key', { action: doAction, original: n, curtxt : n, curnum: 0 }
 				var txt,
 					$this = $(this),
-					action = $this.data('action').split(':')[0],
+					action = $this.data('action').toString().split(':')[0],
 					// prevent mousedown & touchstart from both firing events at the same time - see #184
 					timer = new Date().getTime();
 				if (timer - (base.lastEventTime || 0) < o.preventDoubleEventTime) { return; }


### PR DESCRIPTION
Also set `usePreview: false` in jQuery Mobile demo, which suits this application better.
