### PR TITLE
Removed byte order mark from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "name": "virtual-keyboard",
   "title": "Keyboard",
   "description": "Virtual Keyboard using jQuery UI",


### PR DESCRIPTION
The byte order mark at the beginning of the file prevented jspm from correctly parsing the package.json file.