### PR TITLE
Fixed out the box build failing.

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,17 +8,17 @@
     "url": "https://github.com/jsatt"
   },
   "maintainers": [
-  {
-    "name": "Rob Garrison",
-    "url": "https://github.com/Mottie",
-    "email": "wowmotty@gmail.com"
-  }
+    {
+      "name": "Rob Garrison",
+      "url": "https://github.com/Mottie",
+      "email": "wowmotty@gmail.com"
+    }
   ],
   "licenses": [
-  {
-    "type": "MIT",
-    "url": "http://www.opensource.org/licenses/mit-license.php"
-  }
+    {
+      "type": "MIT",
+      "url": "http://www.opensource.org/licenses/mit-license.php"
+    }
   ],
   "dependencies": {
     "jquery": ">=1.4.3"
@@ -45,11 +45,12 @@
   "devDependencies": {
     "grunt": "~0.4.1",
     "grunt-cli": "~0.1.13",
+    "grunt-contrib-clean": "~0.5.0",
+    "grunt-contrib-concat": "~0.3.0",
+    "grunt-contrib-cssmin": "^0.12.3",
     "grunt-contrib-jshint": "~0.9.2",
     "grunt-contrib-qunit": "~0.4.0",
-    "grunt-contrib-concat": "~0.3.0",
-    "grunt-contrib-uglify": "~0.4.0",
-    "grunt-contrib-clean": "~0.5.0",
+    "grunt-contrib-uglify": "^0.9.1",
     "grunt-contrib-watch": "~0.6.1"
   }
 }


### PR DESCRIPTION
grunt-contrib-css-min was missing from package.json.
grunt-contrib-uglify was failing. See: [Issue 315](https://github.com/gruntjs/grunt-contrib-uglify/issues/315)
Fixed by updating to latest release.

npm install -save-dev triggered alphabetically ordering of dependencies and corrected spacing.