### PR TITLE
Fixed missing tag terminator. Now XHTML compatible.

### DIFF
--- a/js/jquery.keyboard.js
+++ b/js/jquery.keyboard.js
@@ -2099,7 +2099,7 @@ var $keyboard = $.keyboard = function(el, options){
 		if ( typeof $keyboard.checkCaret !== 'boolean' ) {
 			// Check if caret position is saved when input is hidden or loses focus
 			// (*cough* all versions of IE and I think Opera has/had an issue as well
-			var $temp = $('<div style="height:0px;width:0px;overflow:hidden;"><input type="text" value="testing"></div>')
+			var $temp = $('<div style="height:0px;width:0px;overflow:hidden;"><input type="text" value="testing"/></div>')
 				.prependTo( 'body' ); // stop page scrolling
 			$keyboard.caret( $temp.find('input'), 3, 3 );
 			// Also save caret position of the input if it is locked


### PR DESCRIPTION
When I tried to get the keyboard to work in my XHTML based system it failed with strange error messages. A missing ending slash in an input seems to be the culprit..