### PR TITLE
Update russian.js

### DIFF
--- a/layouts/russian.js
+++ b/layouts/russian.js
@@ -80,25 +80,25 @@ jQuery.keyboard.layouts["russian-mac"] = {
 // ru = ISO 639-1 code for Russian
 // ***********************
 jQuery.keyboard.language['ru'] = {
-	language: 'Russian',
+	language: 'Русский',
 	display : {
 		'a'      : '\u2714:Сохранить (Shift-Enter)', // check mark - same action as accept
 		'accept' : 'Сохранить:Сохранить (Shift-Enter)',
 		'alt'    : 'РУС:Русская клавиатура',
-		'b'      : '\u2190:Backspace',    // Left arrow (same as &larr;)
-		'bksp'   : 'Bksp:Backspace',
-		'c'      : '\u2716:Отмена (Esc)', // big X, close - same action as cancel
-		'cancel' : 'Отмена:Отмена (Esc)',
+		'b'      : '\u2190:Удалить символ слева',    // Left arrow (same as &larr;)
+		'bksp'   : '\u21e6:Удалить символ слева',
+		'c'      : '\u2716:Отменить (Esc)', // big X, close - same action as cancel
+		'cancel' : 'Отменить:Отменить (Esc)',
 		'clear'  : 'C:Очистить',             // clear num pad
 		'combo'  : '\u00f6:Toggle Combo Keys',
 		'dec'    : ',:Decimal',           // decimal point for num pad (optional), change '.' to ',' for European format
-		'e'      : '\u21b5:Enter',        // down, then left arrow - enter symbol
-		'enter'  : 'Enter:Enter',
+		'e'      : '\u21b5:Ввод',        // down, then left arrow - enter symbol
+		'enter'  : 'Ввод:Перевод строки',
 		'lock'   : '\u21ea Lock:Caps Lock', // caps lock
-		's'      : '\u21e7:Shift',        // thick hollow up arrow
-		'shift'  : 'Shift:Shift',
+		's'      : '\u21e7:Верхний регистр',        // thick hollow up arrow
+		'shift'  : '\u21e7:Верхний регистр',
 		'sign'   : '\u00b1:Сменить знак',  // +/- sign for num pad
-		'space'  : '&nbsp;:Пробел',
+		'space'  : 'Пробел:',
 		't'      : '\u21e5:Tab',          // right arrow to bar (used since this virtual keyboard works with one directional tabs)
 		'tab'    : '\u21e5 Tab:Tab'       // \u21b9 is the true tab symbol (left & right arrows)
 	},

--- a/layouts/russian.js
+++ b/layouts/russian.js
@@ -79,17 +79,17 @@ jQuery.keyboard.layouts["russian-mac"] = {
 // please update this section to match this language and email me with corrections!
 // ru = ISO 639-1 code for Russian
 // ***********************
-jQuery.keyboard.language.ru = {
+jQuery.keyboard.language['ru'] = {
 	language: 'Russian',
 	display : {
-		'a'      : '\u2714:Accept (Shift-Enter)', // check mark - same action as accept
-		'accept' : 'Accept:Accept (Shift-Enter)',
-		'alt'    : 'AltGr:Alternate Graphemes',
+		'a'      : '\u2714:Сохранить (Shift-Enter)', // check mark - same action as accept
+		'accept' : 'Сохранить:Сохранить (Shift-Enter)',
+		'alt'    : 'РУС:Русская клавиатура',
 		'b'      : '\u2190:Backspace',    // Left arrow (same as &larr;)
 		'bksp'   : 'Bksp:Backspace',
-		'c'      : '\u2716:Cancel (Esc)', // big X, close - same action as cancel
-		'cancel' : 'Cancel:Cancel (Esc)',
-		'clear'  : 'C:Clear',             // clear num pad
+		'c'      : '\u2716:Отмена (Esc)', // big X, close - same action as cancel
+		'cancel' : 'Отмена:Отмена (Esc)',
+		'clear'  : 'C:Очистить',             // clear num pad
 		'combo'  : '\u00f6:Toggle Combo Keys',
 		'dec'    : ',:Decimal',           // decimal point for num pad (optional), change '.' to ',' for European format
 		'e'      : '\u21b5:Enter',        // down, then left arrow - enter symbol
@@ -97,8 +97,8 @@ jQuery.keyboard.language.ru = {
 		'lock'   : '\u21ea Lock:Caps Lock', // caps lock
 		's'      : '\u21e7:Shift',        // thick hollow up arrow
 		'shift'  : 'Shift:Shift',
-		'sign'   : '\u00b1:Change Sign',  // +/- sign for num pad
-		'space'  : '&nbsp;:Space',
+		'sign'   : '\u00b1:Сменить знак',  // +/- sign for num pad
+		'space'  : '&nbsp;:Пробел',
 		't'      : '\u21e5:Tab',          // right arrow to bar (used since this virtual keyboard works with one directional tabs)
 		'tab'    : '\u21e5 Tab:Tab'       // \u21b9 is the true tab symbol (left & right arrows)
 	},


### PR DESCRIPTION
- Access language settings via a dictionary key instead of object property.
- Change "alt" to the same caption as Russian Windows 8 shows (RUS: Russian keyboard).
- Translate "Accept/Cancel/Change sign" since these captions are not commonly recognized in Russian.
- Translate "Space" since in most virtual keyboards it's translated as "Пробел".