### PR TITLE
Add some keyboard data attributes to facilitate access

### DIFF
--- a/js/jquery.keyboard.js
+++ b/js/jquery.keyboard.js
@@ -426,6 +426,7 @@ var $keyboard = $.keyboard = function(el, options){
 				}
 			}
 			base.$keyboard = $keyboard.builtLayouts[base.layout].$keyboard.clone();
+			base.$keyboard.data( 'keyboard', base );
 			if ( ( base.el.id || '' ) !== '' ) {
 				// add ID to keyboard for styling purposes
 				base.$keyboard.attr( 'id', base.el.id + $keyboard.css.idSuffix );
@@ -439,6 +440,7 @@ var $keyboard = $.keyboard = function(el, options){
 				}
 				base.$preview = base.$el.clone(false)
 					.removeAttr('id')
+					.data( 'keyboard', base )
 					.removeClass(kbcss.placeholder + ' ' + kbcss.input)
 					.addClass(kbcss.preview + ' ' + o.css.input)
 					.removeAttr('aria-haspopup')


### PR DESCRIPTION
getkeyboard() works on the keyboard itself or the preview now.

I don't think this should have any unwanted side-effects, as element selections are made based on CSS, not presence of the data attribute.

The problem this change was solving was that noFocus didn't work properly with a preview window. I discovered this when preparing example code for the wiki.