### PR TITLE
Use JQuery position() method instead of DOM .offset{Top|Left}

### DIFF
--- a/js/jquery.keyboard.extension-caret.js
+++ b/js/jquery.keyboard.extension-caret.js
@@ -96,6 +96,7 @@
 			base.findCaretPos = function() {
 				var style, computed, margin, pos, position, txt,
 					element = base.preview,
+					offset = base.$preview.position(),
 					isInput = element.nodeName === 'INPUT',
 					div = base.caret_$div[0];
 
@@ -153,8 +154,8 @@
 				style = Math.round( parseFloat( base.$preview.css( 'font-size' ) ) + margin * 2 ) + o.adjustHt;
 
 				base.$caret.css({
-					top: element.offsetTop - element.scrollTop + base.caretPos.top - margin,
-					left: element.offsetLeft - element.scrollLeft + base.caretPos.left,
+					top: offset.top - element.scrollTop + base.caretPos.top - margin,
+					left: offset.left - element.scrollLeft + base.caretPos.left,
 					height: style
 				});
 				txt = element.value.substring( position, position + o.charIndex ).replace(/\s/, '\xa0' ) || '\xa0';


### PR DESCRIPTION
It seems to allow for table cells better.

Prior to this change, I found that putting an input in a table resulted in the caret not aligning.

Tested on a handful of desktop and tablet browsers and noticed no ill effects.