### PR TITLE
Fix caret when currently focused keyboard is refocused with no preview window

### DIFF
--- a/js/jquery.keyboard.extension-caret.js
+++ b/js/jquery.keyboard.extension-caret.js
@@ -78,7 +78,7 @@
 					.appendTo( base.$keyboard );
 
 				// remove caret, just-in-case
-				base.$keyboard.find('.ui-keyboard-caret').remove();
+				if (base.$caret) base.$caret.remove();
 				base.$caret = $( '<div class="ui-keyboard-caret ' + o.caretClass + '" style="position:absolute;">' )
 					.insertAfter( base.$preview );
 
@@ -181,6 +181,7 @@
 					var events = 'keyup keypress mouseup mouseleave '.split( ' ' ).join( namespace + ' ' );
 					base.$preview.unbind( events );
 					base.$caret.remove();
+					base.$caret = null;
 					base.caret_$div = null;
 				});
 


### PR DESCRIPTION
The code you had in here to fix the caret didn't work without a preview window. I've adjusted and the new code works for my use case. Do you think the change is appropriate? We could still do find() with another context I suppose, though I guess using base.$caret will be faster, and I don't see any reason it shouldn't reference any existing caret.