### PR TITLE
Fix for text area scrolling to beginning in IE and Chrome after clicking a key

### DIFF
--- a/js/jquery.keyboard.js
+++ b/js/jquery.keyboard.js
@@ -535,12 +535,16 @@ var $keyboard = $.keyboard = function(el, options){
 			}
 
 			if ( isTextarea ) {
+				// get current vertical position of scrollbar
+				var scrollTop = $(base.el).scrollTop();
 				// need the textarea scrollHeight, so set the clone textarea height to be the line height
 				base.$previewCopy
 					.height( base.lineHeight )
 					.val( value );
 				// set scrollTop for Textarea
 				base.preview.scrollTop = base.lineHeight * ( Math.floor( base.$previewCopy[0].scrollHeight / base.lineHeight ) - 1 );
+				// reset scrollbar position to original
+				$(base.preview).scrollTop(scrollTop);
 			} else {
 				// add non-breaking spaces
 				base.$previewCopy.val( value.replace(/\s/g, '\xa0') );


### PR DESCRIPTION
Saves the current scrollbar position and then resets it to that
position.