### PR TITLE
if there have 2 different custom layouts, the second one won't be built.

### DIFF
--- a/js/jquery.keyboard.extension-scramble.js
+++ b/js/jquery.keyboard.extension-scramble.js
@@ -187,12 +187,11 @@ $.keyboard = $.keyboard || {};
 					acceptedKeys : [],
 					$keyboard    : null
 				};
-				if ( typeof $.keyboard.builtLayouts[base.orig_layout] === 'undefined' ) {
-					base.layout = opts.layout = base.orig_layout;
-					// build original layout, if not already built, e.g. "qwerty"
-					base.buildKeyboard( base.layout, true );
-					base.layout = opts.layout = layout;
-				}
+				base.layout = opts.layout = base.orig_layout;
+				// build original layout, if not already built, e.g. "qwerty"
+				base.buildKeyboard( base.layout, true );
+				base.layout = opts.layout = layout;
+
 				// clone, scramble then save layout
 				$.keyboard.builtLayouts[layout] = $.extend(true, {}, $.keyboard.builtLayouts[base.orig_layout]);
 				if (o.randomizeOnce) {


### PR DESCRIPTION
I have problem with 2 custom keyboard layouts with scramble , there is the detail. ([Issue](https://github.com/Mottie/Keyboard/issues/493)). 

I trace the code that it will create the keyboard in this block in the jquery.keyboard.js 

``` javascript
if (typeof $keyboard.builtLayouts[base.layout] === 'undefined') {
    if ($.isFunction(o.create)) {
        // create must call buildKeyboard() function; or create it's own keyboard
        base.$keyboard = o.create(base);
    } else if (!base.$keyboard.length) {
        base.buildKeyboard(base.layout, true);
    }
}
```

and it will go to the jquery.keyboard.extension-scramble.js to create the scrambled keyboard, 
however, the **"base.orig_layout"** in jquery.keyboard.extension-scramble.js is **"custom"**, not the layout named with **scrambledXXXX**, so the code woun't enter the block to build keyboard

``` javascript
if ( typeof $.keyboard.builtLayouts[base.orig_layout] === 'undefined' ) {
                    base.layout = opts.layout = base.orig_layout;
                    // build original layout, if not already built, e.g. "qwerty"
                    base.buildKeyboard( base.layout, true );
                    base.layout = opts.layout = layout;
                }
```

I consider that the check of $.keyboard.builtLayouts[base.orig_layout]  should be removed in the "jquery.keyboard.extension-scramble.js", because it will check whether the keyboard layout exists in the " jquery.keyboard.js". 
My problem is resolved after remove this, and share for you review.
Thank you!
