### PR TITLE
Resolve issue #549 - raising keypress by functional keys is Firefox

### DIFF
--- a/js/jquery.keyboard.js
+++ b/js/jquery.keyboard.js
@@ -753,6 +753,11 @@ http://www.opensource.org/licenses/mit-license.php
 					k1 = k >= keyCodes.A && k <= keyCodes.Z,
 					k2 = k >= keyCodes.a && k <= keyCodes.z,
 					str = base.last.key = String.fromCharCode(k);
+				// check, that keypress wasn't rise by functional key
+				// space is first typing symbol in UTF8 table
+				if (k < keyCodes.space){ //see #549
+					return;
+				}
 				base.last.virtual = false;
 				base.last.event = e;
 				base.last.$key = []; // not a virtual keyboard key


### PR DESCRIPTION
I tried to resolve my issue [#549](https://github.com/Mottie/Keyboard/issues/549) by analise difference in behavior of firefox and other browsers. Main difference is different data in event's varibles in firefox for events from text, number and symbols keys and fucntional keys.