### PR TITLE
Clear timer3 timeout on keyboard destroy.

### DIFF
--- a/js/jquery.keyboard.js
+++ b/js/jquery.keyboard.js
@@ -2225,6 +2225,7 @@ http://www.opensource.org/licenses/mit-license.php
 			].join(' ');
 		clearTimeout(base.timer);
 		clearTimeout(base.timer2);
+		clearTimeout(base.timer3);
 		if (base.$keyboard.length) {
 			base.removeKeyboard();
 		}


### PR DESCRIPTION
Hi, I was experiencing some issues while using the destroy() method and 2 keyboards on one page. This seems to have helped. The bug was probably introduced in #542 (cb9c5a49d7f2f79a78fdefaa3a26b0f5135d5e1d)

