### PR TITLE
Prevent exception with browser autocompletion

### DIFF
--- a/js/jquery.keyboard.js
+++ b/js/jquery.keyboard.js
@@ -3088,7 +3088,7 @@ http://www.opensource.org/licenses/mit-license.php
 	};
 
 	$keyboard.caret = function($el, param1, param2) {
-		if (!$el.length || $el.is(':hidden') || $el.css('visibility') === 'hidden') {
+		if (!$el || !$el.length || $el.is(':hidden') || $el.css('visibility') === 'hidden') {
 			return {};
 		}
 		var start, end, txt, pos,


### PR DESCRIPTION
I got an exception with "Google smart lock" in chrome. In single page application, if there is hidden login page where chrome automatically fills user's data. Then keyboard is shown because of autocompletion and we get an exception in $keyboard.caret() function "Cannot read length of null".

With this change, the keyboard is still opened for the hidden field but at least there is no exception.
To prevent opening of the keyboard developers should avoid hidden fields which could be autocompleted.